### PR TITLE
rename some apis for clarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ GoogleSignin.configure({
   offlineAccess: true, // if you want to access Google API on behalf of the user FROM YOUR SERVER
   hostedDomain: '', // specifies a hosted domain restriction
   loginHint: '', // [iOS] The user's ID, or email address, to be prefilled in the authentication UI if possible. [See docs here](https://developers.google.com/identity/sign-in/ios/api/interface_g_i_d_sign_in.html#a0a68c7504c31ab0b728432565f6e33fd)
-  forceConsentPrompt: true, // [Android] if you want to show the authorization prompt at each login.
+  forceCodeForRefreshToken: true, // [Android] read the [docs](https://developers.google.com/android/reference/com/google/android/gms/auth/api/signin/GoogleSignInOptions.Builder#public-googlesigninoptions.builder-requestserverauthcode-string-serverclientid,-boolean-forcecodeforrefreshtoken).
   accountName: '', // [Android] specifies an account name on the device that should be used
   iosClientId: '<FROM DEVELOPER CONSOLE>', // [iOS] optional, if you want to specify the client ID of type iOS (otherwise, it is taken from GoogleService-Info.plist)
 });
@@ -133,7 +133,7 @@ getCurrentUser = async () => {
 };
 ```
 
-#### `clearCachedToken(tokenString)`
+#### `clearCachedAccessToken(accessTokenString)`
 
 This method only has an effect on Android. You may run into a 401 Unauthorized error when a token is invalid. Call this method to remove the token from local cache and then call `getTokens()` to get fresh tokens. Calling this method on iOS does nothing and always resolves. This is because on iOS, `getTokens()` always returns valid tokens, refreshing them first if they have expired or are about to expire (see [docs](https://developers.google.com/identity/sign-in/ios/reference/Classes/GIDAuthentication#-gettokenswithhandler:)).
 

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ GoogleSignin.configure({
   offlineAccess: true, // if you want to access Google API on behalf of the user FROM YOUR SERVER
   hostedDomain: '', // specifies a hosted domain restriction
   loginHint: '', // [iOS] The user's ID, or email address, to be prefilled in the authentication UI if possible. [See docs here](https://developers.google.com/identity/sign-in/ios/api/interface_g_i_d_sign_in.html#a0a68c7504c31ab0b728432565f6e33fd)
-  forceCodeForRefreshToken: true, // [Android] read the [docs](https://developers.google.com/android/reference/com/google/android/gms/auth/api/signin/GoogleSignInOptions.Builder#public-googlesigninoptions.builder-requestserverauthcode-string-serverclientid,-boolean-forcecodeforrefreshtoken).
+  forceCodeForRefreshToken: true, // [Android] related to `serverAuthCode`, read the [docs](https://developers.google.com/android/reference/com/google/android/gms/auth/api/signin/GoogleSignInOptions.Builder#public-googlesigninoptions.builder-requestserverauthcode-string-serverclientid,-boolean-forcecodeforrefreshtoken).
   accountName: '', // [Android] specifies an account name on the device that should be used
   iosClientId: '<FROM DEVELOPER CONSOLE>', // [iOS] optional, if you want to specify the client ID of type iOS (otherwise, it is taken from GoogleService-Info.plist)
 });

--- a/android/src/main/java/co/apptailor/googlesignin/RNGoogleSigninModule.java
+++ b/android/src/main/java/co/apptailor/googlesignin/RNGoogleSigninModule.java
@@ -125,11 +125,11 @@ public class RNGoogleSigninModule extends ReactContextBaseJavaModule {
         final ReadableArray scopes = config.hasKey("scopes") ? config.getArray("scopes") : Arguments.createArray();
         final String webClientId = config.hasKey("webClientId") ? config.getString("webClientId") : null;
         final boolean offlineAccess = config.hasKey("offlineAccess") && config.getBoolean("offlineAccess");
-        final boolean forceConsentPrompt = config.hasKey("forceConsentPrompt") && config.getBoolean("forceConsentPrompt");
+        final boolean forceCodeForRefreshToken = config.hasKey("forceCodeForRefreshToken") && config.getBoolean("forceCodeForRefreshToken");
         final String accountName = config.hasKey("accountName") ? config.getString("accountName") : null;
         final String hostedDomain = config.hasKey("hostedDomain") ? config.getString("hostedDomain") : null;
 
-        GoogleSignInOptions options = getSignInOptions(createScopesArray(scopes), webClientId, offlineAccess, forceConsentPrompt, accountName, hostedDomain);
+        GoogleSignInOptions options = getSignInOptions(createScopesArray(scopes), webClientId, offlineAccess, forceCodeForRefreshToken, accountName, hostedDomain);
         _apiClient = GoogleSignIn.getClient(getReactApplicationContext(), options);
         promise.resolve(null);
     }
@@ -283,8 +283,8 @@ public class RNGoogleSigninModule extends ReactContextBaseJavaModule {
     }
 
     @ReactMethod
-    public void clearCachedToken(String tokenToClear, Promise promise) {
-        if (promiseWrapper.setPromiseWithInProgressCheck(promise, "clearCachedToken")) {
+    public void clearCachedAccessToken(String tokenToClear, Promise promise) {
+        if (promiseWrapper.setPromiseWithInProgressCheck(promise, "clearCachedAccessToken")) {
             new TokenClearingTask(this).execute(tokenToClear);
         }
     }

--- a/android/src/main/java/co/apptailor/googlesignin/Utils.java
+++ b/android/src/main/java/co/apptailor/googlesignin/Utils.java
@@ -57,7 +57,7 @@ public class Utils {
             final Scope[] scopes,
             final String webClientId,
             final boolean offlineAccess,
-            final boolean forceConsentPrompt,
+            final boolean forceCodeForRefreshToken,
             final String accountName,
             final String hostedDomain
     ) {
@@ -66,7 +66,7 @@ public class Utils {
         if (webClientId != null && !webClientId.isEmpty()) {
             googleSignInOptionsBuilder.requestIdToken(webClientId);
             if (offlineAccess) {
-                googleSignInOptionsBuilder.requestServerAuthCode(webClientId, forceConsentPrompt);
+                googleSignInOptionsBuilder.requestServerAuthCode(webClientId, forceCodeForRefreshToken);
             }
         }
         if (accountName != null && !accountName.isEmpty()) {

--- a/example/TokenClearingView.js
+++ b/example/TokenClearingView.js
@@ -3,12 +3,13 @@ import React, { useState, useCallback } from 'react';
 import { Button, TextInput, StyleSheet } from 'react-native';
 import type { User } from '@react-native-community/google-signin';
 import { GoogleSignin } from '@react-native-community/google-signin';
+
 export function TokenClearingView({ userInfo }: { userInfo: User }) {
-  const [tokenToClear, setToken] = useState(userInfo.idToken);
+  const [tokenToClear, setToken] = useState('');
   const clearToken = useCallback(
     async () => {
       try {
-        await GoogleSignin.clearCachedToken(tokenToClear);
+        await GoogleSignin.clearCachedAccessToken(tokenToClear);
         console.warn('success!');
       } catch (err) {
         console.error(err);

--- a/index.d.ts
+++ b/index.d.ts
@@ -76,9 +76,9 @@ export interface ConfigureParams {
   loginHint?: string;
 
   /**
-   * ANDROID ONLY. Specifies if the consent prompt should be shown at each login.
+   * ANDROID ONLY. If true, the granted server auth code can be exchanged for an access token and a refresh token.
    */
-  forceConsentPrompt?: boolean;
+  forceCodeForRefreshToken?: boolean;
 
   /**
    * ANDROID ONLY. An account name that should be prioritized.
@@ -145,7 +145,7 @@ export namespace GoogleSignin {
 
   function getCurrentUser(): Promise<User | null>;
 
-  function clearCachedToken(token: string): Promise<null>;
+  function clearCachedAccessToken(token: string): Promise<null>;
 
   function getTokens(): Promise<{ idToken: string; accessToken: string }>;
 }

--- a/index.js.flow
+++ b/index.js.flow
@@ -9,7 +9,7 @@ export type ConfigureParams = $ReadOnly<{|
   scopes?: string[],
   loginHint?: string,
   hostedDomain?: string,
-  forceConsentPrompt?: boolean,
+  forceCodeForRefreshToken?: boolean,
   accountName?: string,
 |}>;
 
@@ -79,6 +79,6 @@ declare export class GoogleSignin {
   static revokeAccess: () => Promise<null>;
   static isSignedIn: () => Promise<boolean>;
   static getCurrentUser(): Promise<User | null>;
-  static clearCachedToken(token: string): Promise<null>;
+  static clearCachedAccessToken(token: string): Promise<null>;
   static getTokens(): Promise<{ idToken: string, accessToken: string }>;
 }

--- a/src/GoogleSignin.js
+++ b/src/GoogleSignin.js
@@ -62,11 +62,11 @@ class GoogleSignin {
     return RNGoogleSignin.getCurrentUser();
   }
 
-  async clearCachedToken(tokenString) {
+  async clearCachedAccessToken(tokenString) {
     if (!tokenString || typeof tokenString !== 'string') {
-      return Promise.reject('GoogleSignIn: clearCachedToken() expects a string token.');
+      return Promise.reject('GoogleSignIn: clearCachedAccessToken() expects a string token.');
     }
-    return IS_IOS ? true : !(await RNGoogleSignin.clearCachedToken(tokenString));
+    return IS_IOS ? null : await RNGoogleSignin.clearCachedAccessToken(tokenString);
   }
 
   async getTokens() {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

This renames some exposed apis for increased clarity, and is breaking
- `forceConsentPrompt` was renamed to `forceCodeForRefreshToken` and we now link to android docs from readme 
- `clearCachedToken` renamed to `clearCachedAccessToken` because it only works for tokens obtained by previous call to `getToken` and we only use that for `accessToken` [docs](https://developers.google.com/android/reference/com/google/android/gms/auth/GoogleAuthUtil#public-static-void-cleartoken-context-context,-string-token)
- `clearCachedAccessToken` resolves to `null`, it previously resolved to `true`

I'm planning one more breaking thing.

## Test Plan

tested locally

### What's required for testing (prerequisites)?

### What are the steps to reproduce (after prerequisites)?

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅❌     |
| Android |    ✅❌     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
- [x] I added the documentation in `README.md`
- [ ] I mentioned this change in `CHANGELOG.md`
- [x] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
