### PR TITLE
Update android-guide.md

### DIFF
--- a/docs/android-guide.md
+++ b/docs/android-guide.md
@@ -164,6 +164,9 @@ If it is enabled, you will need to add the "App signing certificate" `SHA-1` to 
 
 You can find it at: App -> Release Management (in left sidebar) -> App signing. In there, copy `SHA-1 certificate fingerprint` into firebase console for the Android app.
 
+If you are not using firebase, and your app is enabled for "Google Play App Signing":
+Go to "https://console.developers.google.com/" -> click "Credential in the right panel -> Find "Cilent ID" for type "Android" under "OAuth 2.0 Cilent IDs" section -> Edit -> replace "SHA-1 certificate fingerprint" with the one from App -> Release Management (in left sidebar) -> App signing.
+
 #### My project includes other react-native plugins which have different google play services versions. What to do?
 
 See ["Choose Dependency versions"](#choose-dependency-versions-optional) above.

--- a/docs/android-guide.md
+++ b/docs/android-guide.md
@@ -165,7 +165,7 @@ If it is enabled, you will need to add the "App signing certificate" `SHA-1` to 
 You can find it at: App -> Release Management (in left sidebar) -> App signing. In there, copy `SHA-1 certificate fingerprint` into firebase console for the Android app.
 
 If you are not using firebase, and your app is enabled for "Google Play App Signing":
-Go to "https://console.developers.google.com/" -> click "Credential in the right panel -> Find "Cilent ID" for type "Android" under "OAuth 2.0 Cilent IDs" section -> Edit -> replace "SHA-1 certificate fingerprint" with the one from App -> Release Management (in left sidebar) -> App signing.
+Go to "https://console.developers.google.com/" -> click "Credential" in the right panel -> Find "Client ID" for type "Android" under "OAuth 2.0 Client IDs" section -> Edit -> replace "SHA-1 certificate fingerprint" with the one from App -> Release Management (in left sidebar) -> App signing.
 
 #### My project includes other react-native plugins which have different google play services versions. What to do?
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

If one is not using firebase but "App Signing by Google Play" is enabled. Google sign in fails when app is downloaded from play store. FAQ provides solution by using Firebase but not without.

## Test Plan

Tested changes on the released version downloaded from app store.

### What's required for testing (prerequisites)?
An android app configured for google login, following "without firebase" section under https://github.com/react-native-community/google-signin/blob/master/docs/get-config-file.md

### What are the steps to reproduce (after prerequisites)?
Release an android app to alpha, download the alpha version from app store. Note that google signin fails.

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| Android |    ✅|

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [√ ] I have tested this on a device and a simulator
- [√ ] I added the documentation in `README.md`
- [ ] I mentioned this change in `CHANGELOG.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
