### PR TITLE
fix: Xcode 12 compatibility

### DIFF
--- a/RNGoogleSignin.podspec
+++ b/RNGoogleSignin.podspec
@@ -18,6 +18,6 @@ Pod::Spec.new do |s|
   s.preserve_paths = 'LICENSE', 'README.md'
 
   s.source_files  = "ios/RNGoogleSignin/*.{h,m}"
-  s.dependency "React"
+  s.dependency "React-Core"
   s.dependency "GoogleSignIn", "~> 5.0.0"
 end


### PR DESCRIPTION
# Summary


Xcode 12 fails to build because of the `React` dependency is incorrect and has been so from the beginning. For more information: https://github.com/facebook/react-native/issues/29633#issuecomment-694187116

## Test Plan

Build example project in Xcode 12 in this branch. I will update this PR's checklist as I get to test this myself.

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ❌ (doesn't affect)     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [ ] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I mentioned this change in `CHANGELOG.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
