### PR TITLE
fix RNGoogleSignin.podspec for XCode 12

### DIFF
--- a/RNGoogleSignin.podspec
+++ b/RNGoogleSignin.podspec
@@ -18,6 +18,6 @@ Pod::Spec.new do |s|
   s.preserve_paths = 'LICENSE', 'README.md'
 
   s.source_files  = "ios/RNGoogleSignin/*.{h,m}"
-  s.dependency "React"
+  s.dependency "React-Core"
   s.dependency "GoogleSignIn", "~> 5.0.0"
 end


### PR DESCRIPTION
Xcode 12 won't build if a module depends on React instead of React-Core. 

Reference: https://github.com/facebook/react-native/issues/29633#issuecomment-694187116
